### PR TITLE
Fix sample house manifest

### DIFF
--- a/files/house_manifest.json
+++ b/files/house_manifest.json
@@ -2,20 +2,34 @@
   "lighting_angle": 60,
   "lighting_elevation": 65,
   "depth_influence": 0,
+  "tiled_normals": true,
+  "sampler": "disc",
   "size": {
     "x": 64,
     "y": 64,
     "z": 64
   },
-  "render_elevation": 30,
+  "render_elevation": 23,
   "sprites": [
-    { "angle": 240,
+    { "angle": 45,
       "width": 64,
-      "height": 88
+      "height": 88,
+	  "flip": true
     },
-    { "angle": 330,
+    { "angle": 135,
       "width": 64,
-      "height": 88
+      "height": 88,
+	  "flip": true
+    },
+	{ "angle": 225,
+      "width": 64,
+      "height": 88,
+	  "flip": true
+    },
+	{ "angle": 315,
+      "width": 64,
+      "height": 88,
+	  "flip": true
     }
   ]
 }

--- a/files/house_manifest.json
+++ b/files/house_manifest.json
@@ -3,33 +3,33 @@
   "lighting_elevation": 65,
   "depth_influence": 0,
   "tiled_normals": true,
-  "sampler": "disc",
+  "soften_edges": 0.5,
+  "fade_to_black": false,
+  "sampler": "square",
+  "accuracy": 5,
+  "overlap": 0,
   "size": {
     "x": 64,
     "y": 64,
     "z": 64
   },
-  "render_elevation": 23,
+  "render_elevation": 30,
   "sprites": [
     { "angle": 45,
       "width": 64,
-      "height": 88,
-	  "flip": true
+	     "flip": true
     },
     { "angle": 135,
       "width": 64,
-      "height": 88,
-	  "flip": true
+	    "flip": true
     },
 	{ "angle": 225,
       "width": 64,
-      "height": 88,
-	  "flip": true
+	    "flip": true
     },
-	{ "angle": 315,
+	{  "angle": 315,
       "width": 64,
-      "height": 88,
-	  "flip": true
+	    "flip": true
     }
   ]
 }


### PR DESCRIPTION
Hello,

The house_manifest.json included with GoRender appears to be a placeholder, as the rotations aren't correct and tiled_normals isn't set properly to render the ground tiles. Also, the sprite is flipped horizontally -- I drew an L on the left side of the house in Magicavoxel but it appears reversed on the right side.

![gorender_before](https://user-images.githubusercontent.com/55058389/95798120-20973780-0cbf-11eb-88a3-5ec7c43e75ca.png)

I am using GoRender on a new house set and have updated the manifest with the settings I am using. Besides the rotations, sprite flips, and tiled normals, I have changed the render_elevation to closely match the ground tile template from OpenGFX. It's not perfect, but it's as close as possible. (I will probably render voxel houses and hand-draw my ground tiles.)

![gorender_after](https://user-images.githubusercontent.com/55058389/95798225-5cca9800-0cbf-11eb-9192-2b6934c84ade.png)

I thought this might aid others who wish to use Magicavoxel and GoRender for houses and objects in the future.

Tyler