### PR TITLE
Implement `shadow_threshold` and `soft_shadow` options

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -63,6 +63,8 @@ type Manifest struct {
 	MaxPush                   int              `json:"max_colour_push"`
 	Fosterise                 bool             `json:"fosterise"`
 	NoEdgeFosterisation       bool             `json:"suppress_edge_fosterisation"`
+	SoftShadow                bool             `json:"soft_shadow"`
+	ShadowThreshold           float64          `json:"shadow_threshold"`
 }
 
 func FromJson(handle io.Reader) (manifest Manifest, err error) {


### PR DESCRIPTION
This follows (and contains) #8, and generalizes the shadow handling by introducing two new manifest options `shadow_threshold` and `soft_shadow`. 

* `shadow_threshold` makes the inner product threshold adjustable (rather than hardcoded at 0.0);
* `soft_shadow` introduces a new mode where the shadow strength is in proportion to lighting in excess of `shadow_threshold`.

Now, the old behavior is replicated with `shadow_threshold=-1.0` and `soft_shadow=false`.