### PR TITLE
Implement different tiling modes

### DIFF
--- a/cmd/renderobject.go
+++ b/cmd/renderobject.go
@@ -159,7 +159,7 @@ func processFile(inputFilename string) {
 
 	var processedObject voxelobject.ProcessedVoxelObject
 	timingutils.Time("Voxel processing", flags.OutputTime, func() {
-		processedObject = voxelobject.GetProcessedVoxelObject(object, &palette, manifest.TiledNormals, manifest.SolidBase)
+		processedObject = voxelobject.GetProcessedVoxelObject(object, &palette, manifest.TiledNormals, manifest.TilingMode, manifest.SolidBase)
 	})
 
 	// Check if there are files to output

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/mattkimber/gorender
 
-go 1.15
+go 1.21
 
 require github.com/mattkimber/gandalf v1.3.2

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -42,6 +42,7 @@ type Manifest struct {
 	Sprites                   []Sprite         `json:"sprites"`
 	DepthInfluence            float64          `json:"depth_influence"`
 	TiledNormals              bool             `json:"tiled_normals"`
+	TilingMode                string           `json:"tiling_mode"`
 	SolidBase                 bool             `json:"solid_base"`
 	SoftenEdges               float64          `json:"soften_edges"`
 	Accuracy                  int              `json:"accuracy"`
@@ -71,6 +72,7 @@ func FromJson(handle io.Reader) (manifest Manifest, err error) {
 	// Set defaults
 	manifest.Accuracy = 2
 	manifest.EdgeThreshold = 0.5
+	manifest.TilingMode = "normal"
 
 	data, err := ioutil.ReadAll(handle)
 


### PR DESCRIPTION
Hi,

A problem I have been encountering when working on my modular station set is the limitation in the existing `TiledNormals` option: if a tile is designed to connect with other tiles in ways other than repeating itself, `TiledNormals` often cannot help, and I have to resort in using process colors to control the normals. Which becomes unmanageable with voxel models with lots of moving parts.

So this PR is my attempt to improve the situation. Included in are "tiling modes" that are well-defined in various image processing libraries (such as OpenCV): `repeat` is to assume the outermost elements gets infinitely repeated, `reflect` is to assume that the current tile connects to a mirror image of itself, and `reflect101` is similar but without repeating the border element.