### PR TITLE
Don't skip export when manifest modified recently

### DIFF
--- a/cmd/renderobject.go
+++ b/cmd/renderobject.go
@@ -104,7 +104,7 @@ func processFile(inputFilename string) {
 
 	// Check if there are files to output
 	for _, scale := range splitScales {
-		exist, err := allPotentialOutputFilesExist(inputFilename, scale, numScales)
+		exist, err := allPotentialOutputFilesExist(inputFilename, scale, numScales, flags.ManifestFilename)
 
 		if err != nil {
 			fmt.Printf("error attempting to stat files: %v", err)
@@ -177,7 +177,7 @@ func processFile(inputFilename string) {
 
 }
 
-func allPotentialOutputFilesExist(inputFilename string, scale string, numScales int) (bool, error) {
+func allPotentialOutputFilesExist(inputFilename string, scale string, numScales int, manifestFilepath string) (bool, error) {
 	// Always overwrite files if the flag is set
 	if flags.Overwrite {
 		return false, nil
@@ -195,6 +195,13 @@ func allPotentialOutputFilesExist(inputFilename string, scale string, numScales 
 		check = []string{"8bpp", "32bpp", "mask"}
 	}
 
+	manifestNewer, err := fileIsNewerThanDate(manifestFilepath, inputFileStats.ModTime())
+	if err != nil {
+		return false, err
+	}
+	if manifestNewer {
+		return false, nil
+	}
 	for _, f := range check {
 		newer, err := fileIsNewerThanDate(outputFilename+"_"+f+".png", inputFileStats.ModTime())
 		if err != nil {


### PR DESCRIPTION
Exports will now occur if the manifest file's last modified time is more recent than any exported image file's modified last time. This allows easier testing of various manifest settings.